### PR TITLE
Fix issue where failed connection was seen as successful

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,8 @@ ZIP = zip
 
 # OS specific tools / settings
 ifeq ($(OS),Windows_NT)
-	CHMOD_X = icacls $@ //grant Everyone:F
-	GRANT = icacls $@ //grant Everyone:F
+	CHMOD_X = icacls $@ /grant Everyone:F
+	GRANT = icacls $@ /grant Everyone:F
 	ASTYLE = 3rdparty/astyle.exe
 	OPENGL_HEADERS = /usr/mingw/i686-w64-mingw32/include/GL
 else

--- a/lib/SmartSocket.cpp
+++ b/lib/SmartSocket.cpp
@@ -270,7 +270,7 @@ void SmartSocket::socketDisconnected ( Socket *socket )
     {
         _directSocket.reset();
     }
-    else if ( socket == _directSocket.get() && isConnecting() )
+    else if ( socket == _directSocket.get() && (isConnecting() || isConnected() && !gotGoodRead()) )
     {
         LOG_SMART_SOCKET ( this, "Switching to UDP tunnel" );
 
@@ -282,7 +282,7 @@ void SmartSocket::socketDisconnected ( Socket *socket )
         if ( owner )
             ( ( SmartSocket::Owner * ) owner )->smartSocketSwitchedToUDP ( this );
     }
-    else if ( ( socket == _directSocket.get() && isConnected() ) || socket == _tunSocket.get() )
+    else if ( ( socket == _directSocket.get() && isConnected() && gotGoodRead()) || socket == _tunSocket.get() )
     {
         LOG_SMART_SOCKET ( this, "Tunnel socket disconnected" );
 

--- a/lib/Socket.cpp
+++ b/lib/Socket.cpp
@@ -451,6 +451,8 @@ void Socket::socketRead()
         return;
     }
 
+    _gotGoodRead = true;
+
     // Try to decode as many messages from the buffer as possible
     for ( ;; )
     {

--- a/lib/Socket.hpp
+++ b/lib/Socket.hpp
@@ -82,6 +82,7 @@ public:
     bool isTCP() const { return ( protocol == Protocol::TCP ); }
     bool isUDP() const { return ( protocol == Protocol::UDP ); }
     bool isSmart() const { return ( protocol == Protocol::Smart ); }
+    bool gotGoodRead() const { return _gotGoodRead; }
     virtual State getState() const { return _state; }
     virtual bool isConnecting() const { return isClient() && ( _state == State::Connecting ); }
     virtual bool isConnected() const { return isClient() && ( _state == State::Connected ); }
@@ -145,6 +146,9 @@ protected:
 
     // Raw socket type flag
     bool _isRaw = false;
+
+    // Did we get a successful recv()? If not, it is possible we never really connected
+    bool _gotGoodRead = false;
 
     // Connection state
     State _state = State::Disconnected;

--- a/lib/SocketManager.hpp
+++ b/lib/SocketManager.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <unordered_set>
 
 

--- a/lib/TimerManager.hpp
+++ b/lib/TimerManager.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <unordered_set>
 
 


### PR DESCRIPTION
In some cases we get a false report that we managed to connect to a host even when we didn't. The way to recognize these cases is to check whether at least one `recv()` was successful. This PR ensures that such cases where no recv() was successful will also cause CCCaster to attempt to reconnect via UDP tunnel.